### PR TITLE
Fix native select height in Safari

### DIFF
--- a/source/Native.Select.mint
+++ b/source/Native.Select.mint
@@ -76,6 +76,7 @@ component Ui.Native.Select {
     position: absolute;
     cursor: pointer;
     width: 100%;
+    min-height: 100%;
     z-index: 1;
     opacity: 0;
     bottom: 0;


### PR DESCRIPTION
In Safari, the height of the native select element isn't 100% even
though we've specified all directions (top,left,bottom,right) as zero.

Setting `min-height: 100%` solves the issue.