### PR TITLE
Set the default value of `maxWidth` in `Layout.Website` to `100vw`

### DIFF
--- a/source/Layout.Website.mint
+++ b/source/Layout.Website.mint
@@ -24,7 +24,7 @@ component Ui.Layout.Website {
   property centered : Bool = true
 
   /* The maximum width of the layout. */
-  property maxWidth : String = "100vh"
+  property maxWidth : String = "100vw"
 
   /* Styles for the base element. */
   style base {


### PR DESCRIPTION
I assume that maxWidth of 100v**h** is typo and should be 100v**w**