### PR TITLE
fix: support rows attribute on <textarea>

### DIFF
--- a/source/Textarea.mint
+++ b/source/Textarea.mint
@@ -268,7 +268,8 @@ component Ui.Textarea {
         disabled={disabled}
         onFocus={onFocus}
         onKeyUp={onKeyUp}
-        onBlur={onBlur}/>
+        onBlur={onBlur}
+        rows={Number.toString(rows)}/>
     </div>
   }
 }


### PR DESCRIPTION
I think rows attributed dropped while rendering.
This will fix this.